### PR TITLE
Fix inconsistencies and gaps in User API docs (v2.13 / examples v1.1)

### DIFF
--- a/api-user-examples.md
+++ b/api-user-examples.md
@@ -1,5 +1,15 @@
 # 📋 Common Use Cases - User Management API
 
+<details>
+  <summary><h2>🧩 Version History</h2></summary>
+
+- **v1.0**: Initial draft (2025-08-07)
+- **v1.1**: Fix invalid JSON comment in partial sync example; add X-API-Key auth note; fix Quick Reference table formatting; remove duplicate safety checklist snippet (2026-05-06)
+
+</details>
+
+---
+
 This section shows typical ways customers use the [User API](./api-user.md) — from **business goals** to **exact API calls**.
 
 It’s structured so you can:
@@ -12,12 +22,12 @@ It’s structured so you can:
 
 | Use Case | Endpoint(s) | Key Parameters / Headers | Tips |
 | --- | --- | --- | --- |
-| **[Initial User & Group Onboarding](#initial-user--group-onboarding)** | `POST /api/public/v1/group/importPOST /api/public/v1/functions/{customerId}/importPOST /api/public/v1/recipient/import` | **Body:**`customerOrGroupId`, `username`, `password`,`dryRun`, `externalId`, `groups` / `functions` / `recipients` arrays | Import groups/functions **before** recipients. Use `dryRun=true` to validate. Assign `groups` and `functions` in recipient imports. |
-| **Daily / Scheduled Sync — [Full (Authoritative)](#a-full-sync-authoritative)** | `POST /api/public/v1/recipient/import` | **Body:**`externalId=true`, `partial=false` (optional), `deleteOnlyExternal=true` (optional), `merge=true`, `recipients` array | Use when the feed contains the **entire desired population**. Missing entries are deleted (subject to `deleteOnlyExternal`). Best for authoritative HR/AD exports. |
-| **Daily / Scheduled Sync — [Partial (Append/Update-Only)](#b-partial-sync-appendupdate-only)** | `POST /api/public/v1/recipient/import` | **Body:**`externalId=true`, `partial=true` (optional), `merge=true`, `recipients` array | Use when the feed contains only **new/updated entries**. Existing recipients not in the feed remain untouched. Best for delta updates or incremental syncs. |
-| **[One-off Bulk Updates](#one-off-bulk-updates)** | `POST /api/public/v1/recipient/import` | **Body:**`externalId=true`, `merge=true`, `dryRun=true`, `recipients` array | Ideal for department renames, adding functions, updating emails. Use `merge=true` to avoid overwriting unrelated fields. |
-| **[Selective User or Group Deletion](#selective-user-or-group-deletion)** | `DELETE /api/public/v1/recipient`**or** `POST /api/public/v1/recipient/import` with `recipientsToDelete` / `groupsToDelete` | **Body:**`externalId=true`, `deleteOnlyExternal=true`, `dryRun=true`, `recipientsToDelete` / `groupsToDelete` arrays | Use `deleteOnlyExternal=true` to avoid deleting manually added entries. Always preview with `dryRun=true`. |
-| **[Export for Auditing or Reporting](#export-for-auditing-or-reporting)** | `GET /api/public/v1/recipient/{customerOrGroupId}/exportGET /api/public/v1/group/{customerOrGroupId}/export` | **Headers:**`X-CustomerId`, `X-Username`, `X-Password`,`Accept: application/json` or `text/csv` | Use JSON for integration into BI tools, CSV for Excel/manual review. Export regularly for compliance audits. |
+| **[Initial User & Group Onboarding](#initial-user--group-onboarding)** | `POST /api/public/v1/group/import`<br>`POST /api/public/v1/functions/{customerId}/import`<br>`POST /api/public/v1/recipient/import` | **Body:** `customerOrGroupId`, `username`, `password`, `dryRun`, `externalId`, `groups` / `functions` / `recipients` arrays | Import groups/functions **before** recipients. Use `dryRun=true` to validate. Assign `groups` and `functions` in recipient imports. |
+| **Daily / Scheduled Sync — [Full (Authoritative)](#a-full-sync-authoritative)** | `POST /api/public/v1/recipient/import` | **Body:** `externalId=true`, `partial=false` (optional), `deleteOnlyExternal=true` (optional), `merge=true`, `recipients` array | Use when the feed contains the **entire desired population**. Missing entries are deleted (subject to `deleteOnlyExternal`). Best for authoritative HR/AD exports. |
+| **Daily / Scheduled Sync — [Partial (Append/Update-Only)](#b-partial-sync-appendupdate-only)** | `POST /api/public/v1/recipient/import` | **Body:** `externalId=true`, `partial=true` (optional), `merge=true`, `recipients` array | Use when the feed contains only **new/updated entries**. Existing recipients not in the feed remain untouched. Best for delta updates or incremental syncs. |
+| **[One-off Bulk Updates](#one-off-bulk-updates)** | `POST /api/public/v1/recipient/import` | **Body:** `externalId=true`, `merge=true`, `dryRun=true`, `recipients` array | Ideal for department renames, adding functions, updating emails. Use `merge=true` to avoid overwriting unrelated fields. |
+| **[Selective User or Group Deletion](#selective-user-or-group-deletion)** | `DELETE /api/public/v1/recipient`<br>**or** `POST /api/public/v1/recipient/import` with `recipientsToDelete` / `groupsToDelete` | **Body:** `externalId=true`, `deleteOnlyExternal=true`, `dryRun=true`, `recipientsToDelete` / `groupsToDelete` arrays | Use `deleteOnlyExternal=true` to avoid deleting manually added entries. Always preview with `dryRun=true`. |
+| **[Export for Auditing or Reporting](#export-for-auditing-or-reporting)** | `GET /api/public/v1/recipient/{customerOrGroupId}/export`<br>`GET /api/public/v1/group/{customerOrGroupId}/export` | **Headers:** `X-CustomerId`, `X-Username`, `X-Password`, `Accept: application/json` or `text/csv` | Use JSON for integration into BI tools, CSV for Excel/manual review. Export regularly for compliance audits. |
 
 
 ## **Initial User & Group Onboarding**
@@ -32,6 +42,19 @@ This is ideal for **migrating from spreadsheets** or **loading data from an HR e
 - **Key tips:**
     - Use `dryRun = true` to preview results before committing.
     - Import groups and functions before importing recipients that reference them.
+
+> 💡 **Auth options:** All examples below use Option 2 (username/password). To use **X-API-Key** instead, replace the `username`, `password`, and `customerOrGroupId` body fields with the `X-API-Key` and `X-CustomerId` headers — see the [authentication section](./api-user.md#-authentication) for details. Example for recipient import:
+> ```bash
+> curl -X POST "<BASE_URL>/api/public/v1/recipient/import" \
+>   -H "Content-Type: application/json; charset=utf-8" \
+>   -H "X-API-Key: <YOUR_API_KEY>" \
+>   -H "X-CustomerId: <CUSTOMER_ID>" \
+>   -d '{
+>     "dryRun": true,
+>     "externalId": false,
+>     "recipients": [ { ... } ]
+>   }'
+> ```
 
 **Example Requests:**
 
@@ -211,7 +234,7 @@ curl -X POST "<BASE_URL>/api/public/v1/recipient/import" \
         "msisdn": "+4366412345002",
         "givenname": "Grace",
         "surname": "Hopper",
-        "comment": "Dept: Engineering"   // updates comment only when merge=true
+        "comment": "Dept: Engineering"
       },
       {
         "externalId": "HR-2001",
@@ -242,32 +265,6 @@ curl -X POST "<BASE_URL>/api/public/v1/recipient/import" \
 - Consider `deleteOnlyExternal=true` in Full syncs to protect manually created records.
 - Ensure all identities in your source have unique, stable `externalId` values.
 - If you rely on MSISDN matching, set `merge=true` and keep MSISDNs unique.
-
-```bash
-curl -X POST "<BASE_URL>/api/public/v1/recipient/import" \
-  -H "Content-Type: application/json; charset=utf-8" \
-  -d '{
-    "customerOrGroupId": "<CUSTOMER_ID>",
-    "username": "<API_USER>",
-    "password": "<API_PASS>",
-    "dryRun": false,
-    "externalId": true,
-    "partial": true,
-    "merge": true,
-    "recipients": [
-      {
-        "externalId": "HR-123",
-        "customerId": "<CUSTOMER_ID>",
-        "msisdn": "+4366412345678",
-        "givenname": "Jane",
-        "surname": "Doe",
-        "email": "jane.doe@example.com",
-        "groups": [ { "groupId": "G1" } ]
-      }
-    ]
-  }'
-
-```
 
 ---
 

--- a/api-user.md
+++ b/api-user.md
@@ -16,6 +16,7 @@
 - **v2.10**: Add `functions` to recipient import (2024-01-15)
 - **v2.11**: Rewrite and restructuring (2025-08-07)
 - **v2.12**: Add `X-API-Key` authentication option (2025-08-23)
+- **v2.13**: Fix CSV Content-Type example; expand group/function import sections; fix DELETE param definitions; add export API Key limitation callout; clarify `merge` flag; add rate limits section (2026-05-06)
 
 </details>
 
@@ -98,6 +99,17 @@ For CSV-based or HTTP `GET` / `DELETE` endpoints, credentials must be provided v
 | Vienna   | `https://api.safereach.at/blaulicht` |
 
 If you're unsure, ask support which region your account is in.
+
+---
+
+## ⏱️ Fair Use & Rate Limits
+
+API usage is subject to:
+
+- The **Fair Use Policy**
+- **Account-specific** rate limits
+
+Contact support if you anticipate high-volume imports or require an increase in limits.
 
 ---
 
@@ -186,7 +198,7 @@ If not specified differently, all endpoints require header `Content-Type: applic
 | `dryRun` | Boolean | Optional | false | Only simulate changes |
 | `externalId` | Boolean | Optional | false | Use external IDs |
 | `partial` | Boolean | Optional | false | Don’t delete missing records |
-| `merge` | Boolean | Optional | false | Merge by MSISDN, requires `externalId` |
+| `merge` | Boolean | Optional | false | When `true`, existing records are updated in place rather than replaced. Matching uses `externalId` when `externalId=true`, otherwise falls back to MSISDN. |
 | `deleteOnlyExternal` | Boolean | Optional | false | Only delete records with `externalId` |
 | `recipientsToDelete` | List | Optional | null | List of `externalId` |
 | `groupsToDelete` | List | Optional | null | List of `groupId`s |
@@ -247,9 +259,11 @@ Response:
 
 **`GET /api/public/v1/group/{customerOrGroupId}/export`**
 
+> ⚠️ **API Key auth is not supported for these endpoints.** You must use Option 2 (Admin Account Authentication) with `X-Username` and `X-Password` headers.
+
 **Headers**:
 
-- `X-Username`, `X-Password`
+- `X-CustomerId`, `X-Username`, `X-Password`
 - `Accept`: `application/json` or `text/csv`
 
 **JSON Example**
@@ -276,11 +290,11 @@ UUIDv4;;500027;Jane;Doe;+4366412345678;jane@example.com;;1;0
 
 **Request Body**:
 
-| Parameter | Required | Description |
-| --- | --- | --- |
-| `dryRun` | ✅ Yes | Preview vs delete |
-| `externalId` | ✅ Yes | Use externalId matching |
-| `recipients` | ✅ Yes | List of `RecipientBaseData` |
+| Parameter | Required | Default | Description |
+| --- | --- | --- | --- |
+| `dryRun` | Optional | false | Preview the result without deleting. Strongly recommended before first run. |
+| `externalId` | Optional | false | Match recipients by `externalId` instead of internal `id` |
+| `recipients` | ✅ Yes | — | List of `RecipientBaseData` |
 
 **Example**
 
@@ -315,14 +329,102 @@ Response:
 
 ---
 
-### Import Groups / Functions
+### Import Groups
 
 **`POST /api/public/v1/group/import`**
 
+| Parameter | Type | Required | Default | Description |
+| --- | --- | --- | --- | --- |
+| `dryRun` | Boolean | Optional | false | Only simulate changes |
+| `externalId` | Boolean | Optional | false | Use external IDs |
+| `partial` | Boolean | Optional | false | Don't delete missing records |
+| `merge` | Boolean | Optional | false | Merge by groupId |
+| `deleteOnlyExternal` | Boolean | Optional | false | Only delete records with `externalId` |
+| `groupsToDelete` | List | Optional | null | List of `groupId`s to delete |
+| `groups` | List | ✅ Yes | — | List of `GroupData` objects |
+
+> ⚠️ **Known issue:** Creating groups with `externalId` set results in system groups that cannot be edited or deleted. See [Known Issues](#-known-issues).
+
+**Example**
+
+Request:
+
+```json
+{
+  "customerOrGroupId": "500027",
+  "username": "<API_USER>",
+  "password": "<API_PASS>",
+  "dryRun": true,
+  "externalId": false,
+  "groups": [
+    { "id": "", "externalId": "", "customerId": "500027", "groupId": "G1", "name": "Operations" },
+    { "id": "", "externalId": "", "customerId": "500027", "groupId": "G2", "name": "IT" }
+  ]
+}
+```
+
+Response:
+
+```json
+{
+  "result": "OK",
+  "created": 2,
+  "updated": 0,
+  "deleted": 0,
+  "request": {
+    "dryRun": true,
+    "externalId": false
+  }
+}
+```
+
+---
+
+### Import Functions
+
 **`POST /api/public/v1/functions/{customerId}/import`**
 
-- Accepts same flags as `/recipient/import`
-- `groups` and `functions` are lists of `GroupData` / `FunctionData`
+> Note: Unlike the group and recipient import endpoints, the customer ID is passed as a **path variable** (`{customerId}`) rather than solely in the request body.
+
+| Parameter | Type | Required | Default | Description |
+| --- | --- | --- | --- | --- |
+| `dryRun` | Boolean | Optional | false | Only simulate changes |
+| `externalId` | Boolean | Optional | false | Use external IDs |
+| `partial` | Boolean | Optional | false | Don't delete missing records |
+| `functions` | List | ✅ Yes | — | List of `FunctionData` objects |
+
+**Example**
+
+Request:
+
+```json
+{
+  "customerOrGroupId": "500027",
+  "username": "<API_USER>",
+  "password": "<API_PASS>",
+  "dryRun": true,
+  "externalId": false,
+  "functions": [
+    { "id": "", "externalId": "", "customerId": "500027", "functionCode": "F1", "name": "First Aid Officer" },
+    { "id": "", "externalId": "", "customerId": "500027", "functionCode": "F2", "name": "Crisis Manager" }
+  ]
+}
+```
+
+Response:
+
+```json
+{
+  "result": "OK",
+  "created": 2,
+  "updated": 0,
+  "deleted": 0,
+  "request": {
+    "dryRun": true,
+    "externalId": false
+  }
+}
+```
 
 ---
 
@@ -348,7 +450,7 @@ POST /blaulicht/api/public/v1/recipient/import?dryRun=true&merge=false HTTP/1.1
 Host: api.safereach.com
 X-API-Key: your-api-key-here
 X-CustomerId: 500027
-Content-Type: application/json; charset=utf-8
+Content-Type: text/csv
 
 id;externalId;customerId;givenname;surname;msisdn;email;comment;G1;G2
 ;;500027;Max;Mustermann;+4366412345678;max@example.com;Ops;1;0


### PR DESCRIPTION
Bugs fixed:
- CSV import example had wrong Content-Type (application/json → text/csv)
- Invalid JS comment inside JSON code block in partial sync example

Structural fixes:
- DELETE /recipient: dryRun and externalId were incorrectly marked required; corrected to Optional with defaults
- Export endpoints: added ⚠️ callout that X-API-Key auth is not supported, and added missing X-CustomerId header
- Import Groups/Functions stub expanded into two full sections with params tables, request/response examples, and a note on the URL structure difference (functions embed {customerId} in path)
- merge flag description rewritten to clarify externalId vs MSISDN matching strategy

Gaps filled:
- Added X-API-Key auth example callout to examples doc
- Added Fair Use & Rate Limits section (matches sibling API docs)
- Quick Reference table: fixed run-together cell text with <br> separators
- Removed duplicate partial sync curl snippet from safety checklist

Version history updated in both files.